### PR TITLE
Update readme with installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,20 @@
-Eclipse-GotoFile-Plugin-kai
-===========================
-
-Modified muermann's goto file plugin
-
-http://www.muermann.org/gotofile/
+# Eclipse-GotoFile-Plugin-kai
+Modified [muermann's goto file plugin][]
 
 This plugin adds fuzzy search ability with project oriented path to eclipse default 'open resource' command.
 
-License: LGPL (http://www.gnu.org/licenses/lgpl.html)
+## Usage
+Type `Ctrl+Alt+N` to use.
 
-Type Ctrl+Alt+N to use. Works with Eclipse Juno.
+Ex.: `koin` will be matched to `knockout/index.html`
 
-Ex.:: ``koin`` will be matched to ``knockout/index.html``
+## Installation
+Download the raw org.muermann.gotofile_1.3.5.jar from this repo and copy it to the plugins folder of your Eclipse installation.
+
+This has been tested up to Eclipse Luna.
+
+## License
+[LGPL][lgpl]
+
+[orig]: https://web.archive.org/web/20121013050850/http://www.muermann.org/gotofile
+[lgpl]: http://www.gnu.org/licenses/lgpl.html


### PR DESCRIPTION
Also
- make the link to muermann's website use archive.org since it has 404'd for years
- organize readme into usage, installation, and license sections
- make headings and links into default markdown
- add that I've tested it with Eclipse Luna
